### PR TITLE
Replace / with _ in bridge node name

### DIFF
--- a/launch/gz_components.launch.py
+++ b/launch/gz_components.launch.py
@@ -68,6 +68,8 @@ def get_launch_description(name: str, package: str, namespace: str, component: y
     if component_name_gz_prefix != "":
         gz_bridge_name_prefix = component_name_gz_prefix + "_" + gz_bridge_name_prefix
 
+    gz_bridge_name_prefix = gz_bridge_name_prefix.replace("/", "_")
+
     if "ur" not in name and "kinova" not in name and "robotiq" not in name:
         if len(robot_namespace) and robot_namespace[0] != "/":
             robot_namespace = "/" + robot_namespace


### PR DESCRIPTION
Bug:
```bash
[ERROR] [launch_ros.actions.node]: Error while expanding or validating node name or namespace for 'package=ros_gz_bridge, executable=parameter_bridge, name=<launch.substitutions.launch_configuration.LaunchConfiguration object at 0x7da37c536ea0>, namespace=<launch.substitutions.launch_configuration.LaunchConfiguration object at 0x7da37c537b00>':
[ERROR] [launch]: Caught exception in launch (see debug for traceback): Invalid node name: node name must not contain characters other than alphanumerics or '_':
  'ns1/name_ANT02_gz_bridge'
        ^
  ```

Config file:
```yaml
components:
  - type: ANT02
    parent_link: mount_link
    xyz: -0.185 0.0 0.0
    rpy: 0.0 0.0 0.0
    name: ns1/name
```