### PR TITLE
Add tf_prefix arg and fix depthai reference frame for camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ To include the sensor, use the following code:
   rpy="0.0 0.0 0.0" />
 ```
 
-A list of parameters can be found here:
+List of parameters:
 
 - `component_name` [*string*, default: **''**] local namespace allowing to distinguish two identical devices from each other. Called `name` in `components.yaml`.
 - `parent_link` [*string*, default: **None**] parent link to which sensor should be attached.
@@ -89,5 +89,6 @@ A list of parameters can be found here:
 - `rpy` [*float list*, default: **0.0 0.0 0.0**] 3 float values define rotation between parent link and base of a sensor. Values in **rad**.
 - `robot_namespace` [*string*, default: **''**] global namespace common to the entire robot. Not present in  `components.yaml`.
 - `model` [*string*, default: **''**] model argument that appears when you want to load the appropriate model from a given manufacturer. Not present in `components.yaml`.
+- `use_tf_prefix` [*bool*, default: **True**] if set to True, the `robot_namespace` will be used as a prefix for all frame_ids defined in the sensor URDF. This is useful when evry robot has its own tf tree. Not present in `components.yaml`.
 
 Some sensors can define their specific parameters. Refer to their definition for more info.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,6 @@ List of parameters:
 - `rpy` [*float list*, default: **0.0 0.0 0.0**] 3 float values define rotation between parent link and base of a sensor. Values in **rad**.
 - `robot_namespace` [*string*, default: **''**] global namespace common to the entire robot. Not present in  `components.yaml`.
 - `model` [*string*, default: **''**] model argument that appears when you want to load the appropriate model from a given manufacturer. Not present in `components.yaml`.
-- `use_tf_prefix` [*bool*, default: **True**] if set to True, the `robot_namespace` will be used as a prefix for all frame_ids defined in the sensor URDF. This is useful when evry robot has its own tf tree. Not present in `components.yaml`.
+- `use_tf_prefix` [*bool*, default: **True**] if set to True, the `robot_namespace` will be used as a prefix for all frame_ids defined in the sensor URDF. This is useful when every robot has its own tf tree. Not present in `components.yaml`.
 
 Some sensors can define their specific parameters. Refer to their definition for more info.

--- a/urdf/components.urdf.xacro
+++ b/urdf/components.urdf.xacro
@@ -19,23 +19,24 @@ limitations under the License.
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
 
   <xacro:macro name="create_components"
-    params="components_config_path namespace:='' use_sim:=False">
+              params="components_config_path
+                      namespace:=''
+                      use_sim:=False
+                      use_tf_prefix:=True">
 
     <xacro:unless value="${components_config_path == ''}">
-        <xacro:property
-          name="components_config"
-          value="${xacro.load_yaml(components_config_path)}" />
+      <xacro:property name="components_config" value="${xacro.load_yaml(components_config_path)}" />
       <xacro:load_componenet
         config="${components_config}"
         counter="${len(components_config['components'])}"
         robot_namespace="${namespace}"
-        use_sim="${use_sim}" />
-
+        use_sim="${use_sim}"
+        use_tf_prefix="${use_tf_prefix}" />
     </xacro:unless>
   </xacro:macro>
 
   <xacro:macro name="load_componenet"
-    params="config counter robot_namespace use_sim:=False">
+    params="config counter robot_namespace use_sim:=False use_tf_prefix:=True">
     <xacro:if value="${counter}">
       <xacro:property name="index" value="${counter - 1}" scope="parent" />
       <xacro:property name="component" value="${config['components'][index]}" scope="parent" />
@@ -83,6 +84,7 @@ limitations under the License.
             rpy="${rpy}"
             robot_namespace="${robot_namespace}"
             component_name="${component_name}"
+            use_tf_prefix="${use_tf_prefix}"
           />
         </xacro:if>
 
@@ -97,6 +99,7 @@ limitations under the License.
             rpy="${rpy}"
             robot_namespace="${robot_namespace}"
             component_name="${component_name}"
+            use_tf_prefix="${use_tf_prefix}"
           />
         </xacro:if>
 
@@ -112,6 +115,7 @@ limitations under the License.
             robot_namespace="${robot_namespace}"
             component_name="${component_name}"
             use_nominal_extrinsics="${use_sim}"
+            use_tf_prefix="${use_tf_prefix}"
           />
         </xacro:if>
 
@@ -129,13 +133,13 @@ limitations under the License.
             ns="camera" />
 
           <xacro:camera.zed_camera
-
             parent_link="${parent_link}"
             xyz="${xyz}"
             rpy="${rpy}"
             robot_namespace="${robot_namespace}"
             component_name="${component_name}"
             model="${zed_models_dict[type]}"
+            use_tf_prefix="${use_tf_prefix}"
           />
         </xacro:if>
 
@@ -157,6 +161,7 @@ limitations under the License.
             robot_namespace="${robot_namespace}"
             component_name="${component_name}"
             model="${luxonis_models_dict[type]}"
+            use_tf_prefix="${use_tf_prefix}"
           />
         </xacro:if>
 
@@ -182,6 +187,7 @@ limitations under the License.
             robot_namespace="${robot_namespace}"
             component_name="${component_name}"
             model="${rplidar_models_dict[type]}"
+            use_tf_prefix="${use_tf_prefix}"
           />
         </xacro:if>
 
@@ -207,6 +213,7 @@ limitations under the License.
             robot_namespace="${robot_namespace}"
             component_name="${component_name}"
             model="${ouster_models_dict[type]}"
+            use_tf_prefix="${use_tf_prefix}"
           />
         </xacro:if>
 
@@ -222,6 +229,7 @@ limitations under the License.
             rpy="${rpy}"
             robot_namespace="${robot_namespace}"
             component_name="${component_name}"
+            use_tf_prefix="${use_tf_prefix}"
           />
         </xacro:if>
 
@@ -237,6 +245,7 @@ limitations under the License.
             rpy="${rpy}"
             component_name="${component_name}"
             ur_type="ur3e"
+            use_tf_prefix="${use_tf_prefix}"
           />
         </xacro:if>
 
@@ -252,6 +261,7 @@ limitations under the License.
             rpy="${rpy}"
             component_name="${component_name}"
             ur_type="ur5e"
+            use_tf_prefix="${use_tf_prefix}"
           />
         </xacro:if>
 
@@ -272,6 +282,7 @@ limitations under the License.
             dof="6"
             gripper="robotiq_2f_85"
             vision="false"
+            use_tf_prefix="${use_tf_prefix}"
           />
         </xacro:if>
 
@@ -291,6 +302,7 @@ limitations under the License.
             dof="6"
             gripper="robotiq_2f_85"
             vision="true"
+            use_tf_prefix="${use_tf_prefix}"
           />
         </xacro:if>
 
@@ -310,6 +322,7 @@ limitations under the License.
             dof="7"
             gripper="robotiq_2f_85"
             vision="false"
+            use_tf_prefix="${use_tf_prefix}"
           />
         </xacro:if>
 
@@ -329,6 +342,7 @@ limitations under the License.
             gripper="robotiq_2f_85"
             vision="true"
             component_name="${component_name}"
+            use_tf_prefix="${use_tf_prefix}"
           />
         </xacro:if>
 
@@ -342,6 +356,7 @@ limitations under the License.
             rpy="${rpy}"
             component_name="${component_name}"
             robotiq_type="2f_85"
+            use_tf_prefix="${use_tf_prefix}"
           />
         </xacro:if>
 
@@ -356,6 +371,7 @@ limitations under the License.
             rpy="${rpy}"
             robot_namespace="${robot_namespace}"
             component_name="${component_name}"
+            use_tf_prefix="${use_tf_prefix}"
           />
         </xacro:if>
       </xacro:unless>
@@ -366,6 +382,7 @@ limitations under the License.
           config="${config}"
           robot_namespace="${robot_namespace}"
           use_sim="${use_sim}"
+          use_tf_prefix="${use_tf_prefix}"
         />
       </xacro:if>
     </xacro:if>

--- a/urdf/components.urdf.xacro
+++ b/urdf/components.urdf.xacro
@@ -245,7 +245,6 @@ limitations under the License.
             rpy="${rpy}"
             component_name="${component_name}"
             ur_type="ur3e"
-            use_tf_prefix="${use_tf_prefix}"
           />
         </xacro:if>
 
@@ -261,7 +260,6 @@ limitations under the License.
             rpy="${rpy}"
             component_name="${component_name}"
             ur_type="ur5e"
-            use_tf_prefix="${use_tf_prefix}"
           />
         </xacro:if>
 
@@ -356,7 +354,6 @@ limitations under the License.
             rpy="${rpy}"
             component_name="${component_name}"
             robotiq_type="2f_85"
-            use_tf_prefix="${use_tf_prefix}"
           />
         </xacro:if>
 
@@ -371,7 +368,6 @@ limitations under the License.
             rpy="${rpy}"
             robot_namespace="${robot_namespace}"
             component_name="${component_name}"
-            use_tf_prefix="${use_tf_prefix}"
           />
         </xacro:if>
       </xacro:unless>

--- a/urdf/intel_realsense_d435.urdf.xacro
+++ b/urdf/intel_realsense_d435.urdf.xacro
@@ -24,13 +24,15 @@ limitations under the License.
                        rpy:='0.0 0.0 0.0'
                        use_nominal_extrinsics:=false
                        robot_namespace:=''
-                       component_name:=''">
+                       component_name:=''
+                       use_tf_prefix:=True">
 
     <xacro:if value="${component_name == ''}">
       <xacro:property name="component_name" value="camera" />
     </xacro:if>
 
     <xacro:property name="robot_namespace_slash" value="${robot_namespace + '/' if robot_namespace != '' else ''}" />
+    <xacro:property name="tf_prefix" value="${robot_namespace_slash if use_tf_prefix in ['True', True] else ''}" />
     <xacro:property name="component_name_underscore" value="${component_name + '_' if component_name != '' else ''}" />
     <xacro:property name="component_name_slash" value="${component_name + '/' if component_name != '' else ''}" />
 
@@ -177,7 +179,7 @@ limitations under the License.
       reference="${component_name_underscore}link"
       name="${robot_namespace_slash}${component_name_underscore}intel_realsense_d435_color"
       topic="${robot_namespace_slash}${component_name_slash}color/image_raw"
-      frame_id="${robot_namespace_slash}${component_name_underscore}color_optical_frame"
+      frame_id="${tf_prefix}${component_name_underscore}color_optical_frame"
       frequency="30"
       width="1280"
       height="720"
@@ -187,7 +189,7 @@ limitations under the License.
       reference="${component_name_underscore}link"
       name="${robot_namespace_slash}${component_name_underscore}intel_realsense_d435_depth"
       topic="${robot_namespace_slash}${component_name_slash}depth/image_rect_raw"
-      frame_id="${robot_namespace_slash}${component_name_underscore}depth_optical_frame"
+      frame_id="${tf_prefix}${component_name_underscore}depth_optical_frame"
       frequency="30"
       width="1280"
       height="720"

--- a/urdf/kinova.urdf.xacro
+++ b/urdf/kinova.urdf.xacro
@@ -58,13 +58,15 @@ limitations under the License.
                        gripper:=''
                        vision:=false
                        robot_namespace:=''
-                       component_name:=''">
+                       component_name:=''
+                       use_tf_prefix:=True">
 
     <xacro:if value="${component_name == ''}">
       <xacro:property name="component_name" value="kinova" />
     </xacro:if>
 
     <xacro:property name="robot_namespace_slash" value="${robot_namespace + '/' if robot_namespace != '' else ''}" />
+    <xacro:property name="tf_prefix" value="${robot_namespace_slash if use_tf_prefix in ['True', True] else ''}" />
     <xacro:property name="component_name_underscore" value="${component_name + '_' if component_name != '' else ''}" />
     <xacro:property name="component_name_slash" value="${component_name + '/' if component_name != '' else ''}" />
 
@@ -204,7 +206,7 @@ limitations under the License.
             </depth_camera>
             <optical_frame_id>${component_name_underscore}color_optical_frame</optical_frame_id>
           </camera>
-          <gz_frame_id>${robot_namespace_slash}${component_name_underscore}camera_color_frame</gz_frame_id>
+          <gz_frame_id>${tf_prefix}${component_name_underscore}camera_color_frame</gz_frame_id>
           <always_on>1</always_on>
           <update_rate>${camera_fps}</update_rate>
           <visualize>true</visualize>

--- a/urdf/luxonis_depthai.urdf.xacro
+++ b/urdf/luxonis_depthai.urdf.xacro
@@ -24,13 +24,15 @@ limitations under the License.
                        robot_namespace:=''
                        component_name:=''
                        model:='OAK-D-PRO'
-                       use_sim:=False">
+                       use_sim:=False
+                       use_tf_prefix:=True">
 
     <xacro:if value="${component_name == ''}">
       <xacro:property name="component_name" value="oak" />
     </xacro:if>
 
     <xacro:property name="robot_namespace_slash" value="${robot_namespace + '/' if robot_namespace != '' else ''}" />
+    <xacro:property name="tf_prefix" value="${robot_namespace_slash if use_tf_prefix in ['True', True] else ''}" />
     <xacro:property name="component_name_underscore" value="${component_name + '_' if component_name != '' else ''}" />
     <xacro:property name="component_name_slash" value="${component_name + '/' if component_name != '' else ''}" />
 
@@ -40,7 +42,7 @@ limitations under the License.
     <xacro:include filename="$(find depthai_descriptions)/urdf/include/depthai_macro.urdf.xacro" />
 
     <xacro:depthai_camera camera_name="${component_name}" parent="${parent_link}"
-      base_frame="${robot_namespace_slash}${component_name_underscore_nonempty}link" camera_model="${model}"
+      base_frame="${component_name_underscore_nonempty}link" camera_model="${model}"
       cam_pos_x="${xyz.split()[0]}" cam_pos_y="${xyz.split()[1]}" cam_pos_z="${xyz.split()[2]}"
       cam_roll="${rpy.split()[0]}" cam_pitch="${rpy.split()[1]}" cam_yaw="${rpy.split()[2]}"
       simulation="${use_sim}" />
@@ -52,7 +54,7 @@ limitations under the License.
       reference="${component_name_underscore_nonempty}link"
       name="${robot_namespace_slash}${component_name_underscore}color"
       topic="${robot_namespace_slash}${component_name_slash}rgb/color"
-      frame_id="${robot_namespace_slash}${component_name_underscore}rgb_camera_frame"
+      frame_id="${tf_prefix}${component_name_underscore}rgb_camera_frame"
       frequency="30"
       width="1280"
       height="720"
@@ -62,7 +64,7 @@ limitations under the License.
       reference="${component_name_underscore_nonempty}link"
       name="${robot_namespace_slash}${component_name_underscore}depth"
       topic="${robot_namespace_slash}${component_name_slash}stereo/depth"
-      frame_id="${robot_namespace_slash}${component_name_underscore}rgb_camera_frame"
+      frame_id="${tf_prefix}${component_name_underscore}rgb_camera_frame"
       frequency="30"
       width="1280"
       height="720"

--- a/urdf/orbbec_astra.urdf.xacro
+++ b/urdf/orbbec_astra.urdf.xacro
@@ -22,13 +22,15 @@ limitations under the License.
                        xyz:='0.0 0.0 0.0'
                        rpy:='0.0 0.0 0.0'
                        robot_namespace:=''
-                       component_name:=''">
+                       component_name:=''
+                       use_tf_prefix:=True">
 
     <xacro:if value="${component_name == ''}">
       <xacro:property name="component_name" value="camera" />
     </xacro:if>
 
     <xacro:property name="robot_namespace_slash" value="${robot_namespace + '/' if robot_namespace != '' else ''}" />
+    <xacro:property name="tf_prefix" value="${robot_namespace_slash if use_tf_prefix in ['True', True] else ''}" />
     <xacro:property name="component_name_underscore" value="${component_name + '_' if component_name != '' else ''}" />
     <xacro:property name="component_name_slash" value="${component_name + '/' if component_name != '' else ''}" />
 
@@ -139,7 +141,7 @@ limitations under the License.
       reference="${component_name_underscore}link"
       name="${robot_namespace_slash}${component_name_underscore}camera_color"
       topic="${robot_namespace_slash}${component_name_slash}color/image_raw"
-      frame_id="${robot_namespace_slash}${component_name_underscore}color_optical_frame"
+      frame_id="${tf_prefix}${component_name_underscore}color_optical_frame"
       frequency="30"
       width="640"
       height="480"
@@ -149,7 +151,7 @@ limitations under the License.
       reference="${component_name_underscore}link"
       name="${robot_namespace_slash}${component_name_underscore}camera_depth"
       topic="${robot_namespace_slash}${component_name_slash}depth/image_raw"
-      frame_id="${robot_namespace_slash}${component_name_underscore}depth_optical_frame"
+      frame_id="${tf_prefix}${component_name_underscore}depth_optical_frame"
       frequency="30"
       width="640"
       height="480"

--- a/urdf/ouster.urdf.xacro
+++ b/urdf/ouster.urdf.xacro
@@ -23,7 +23,8 @@ limitations under the License.
                        rpy:='0.0 0.0 0.0'
                        model:=os1_32
                        robot_namespace:=''
-                       component_name:=''">
+                       component_name:=''
+                       use_tf_prefix:=True">
 
     <!-- <xacro:if value="${component_name == ''}">
       <xacro:property name="component_name" value="ouster" />
@@ -31,6 +32,7 @@ limitations under the License.
     <!-- ^ removed for compatibility with hw driver -->
 
     <xacro:property name="robot_namespace_slash" value="${robot_namespace + '/' if robot_namespace != '' else ''}" />
+    <xacro:property name="tf_prefix" value="${robot_namespace_slash if use_tf_prefix in ['True', True] else ''}" />
     <xacro:property name="component_name_underscore" value="${component_name + '_' if component_name != '' else ''}" />
     <xacro:property name="component_name_slash" value="${component_name + '/' if component_name != '' else ''}" />
 
@@ -153,7 +155,7 @@ limitations under the License.
         <update_rate>20.0</update_rate>
 
         <topic>${robot_namespace_slash}${component_name_slash}ouster/points</topic>
-        <gz_frame_id>${robot_namespace_slash}${component_name_underscore}os_lidar</gz_frame_id>
+        <gz_frame_id>${tf_prefix}${component_name_underscore}os_lidar</gz_frame_id>
         <always_on>true</always_on>
       </sensor>
     </gazebo>

--- a/urdf/slamtec_rplidar.urdf.xacro
+++ b/urdf/slamtec_rplidar.urdf.xacro
@@ -23,7 +23,8 @@ limitations under the License.
                        rpy:='0.0 0.0 0.0'
                        robot_namespace:=''
                        component_name:=''
-                       model:=s3">
+                       model:=s3
+                       use_tf_prefix:=True">
 
     <!-- <xacro:if value="${component_name == ''}">
       <xacro:property name="component_name" value="rplidar" />
@@ -31,6 +32,7 @@ limitations under the License.
     <!-- ^ removed for compatibility with hw driver -->
 
     <xacro:property name="robot_namespace_slash" value="${robot_namespace + '/' if robot_namespace != '' else ''}" />
+    <xacro:property name="tf_prefix" value="${robot_namespace_slash if use_tf_prefix in ['True', True] else ''}" />
     <xacro:property name="component_name_underscore" value="${component_name + '_' if component_name != '' else ''}" />
     <xacro:property name="component_name_slash" value="${component_name + '/' if component_name != '' else ''}" />
 
@@ -263,7 +265,7 @@ limitations under the License.
         <visualize>false</visualize>
 
         <topic>${robot_namespace_slash}${component_name_slash}scan</topic>
-        <gz_frame_id>${robot_namespace_slash}${component_name_underscore}laser</gz_frame_id>
+        <gz_frame_id>${tf_prefix}${component_name_underscore}laser</gz_frame_id>
 
         <ray>
           <scan>

--- a/urdf/stereolabs_zed.urdf.xacro
+++ b/urdf/stereolabs_zed.urdf.xacro
@@ -27,13 +27,15 @@ limitations under the License.
                        rpy:='0.0 0.0 0.0'
                        model:=zed
                        robot_namespace:=''
-                       component_name:=''">
+                       component_name:=''
+                       use_tf_prefix:=True">
 
     <xacro:if value="${component_name == ''}">
       <xacro:property name="component_name" value="zed" />
     </xacro:if>
 
     <xacro:property name="robot_namespace_slash" value="${robot_namespace + '/' if robot_namespace != '' else ''}" />
+    <xacro:property name="tf_prefix" value="${robot_namespace_slash if use_tf_prefix in ['True', True] else ''}" />
     <xacro:property name="component_name_underscore" value="${component_name + '_' if component_name != '' else ''}" />
     <xacro:property name="component_name_slash" value="${component_name + '/' if component_name != '' else ''}" />
 
@@ -332,7 +334,7 @@ limitations under the License.
       reference="${component_name_underscore}camera_center"
       name="${robot_namespace_slash}${component_name_underscore}camera_color"
       topic="${robot_namespace_slash}${component_name_slash}zed_node/rgb/image_rect_color"
-      frame_id="${robot_namespace_slash}${component_name_underscore}camera_center"
+      frame_id="${tf_prefix}${component_name_underscore}camera_center"
       frequency="30"
       width="1280"
       height="720"
@@ -342,7 +344,7 @@ limitations under the License.
       reference="${component_name_underscore}camera_center"
       name="${robot_namespace_slash}${component_name_underscore}camera_depth"
       topic="${robot_namespace_slash}${component_name_slash}zed_node/depth"
-      frame_id="${robot_namespace_slash}${component_name_underscore}camera_center"
+      frame_id="${tf_prefix}${component_name_underscore}camera_center"
       frequency="30"
       width="1280"
       height="720"

--- a/urdf/teltonika_003R-00253.urdf.xacro
+++ b/urdf/teltonika_003R-00253.urdf.xacro
@@ -22,13 +22,15 @@ limitations under the License.
                        xyz:='0.0 0.0 0.0'
                        rpy:='0.0 0.0 0.0'
                        robot_namespace:=''
-                       component_name:=''">
+                       component_name:=''
+                       use_tf_prefix:=True">
 
     <xacro:if value="${component_name == ''}">
       <xacro:property name="component_name" value="gps" />
     </xacro:if>
 
     <xacro:property name="robot_namespace_slash" value="${robot_namespace + '/' if robot_namespace != '' else ''}" />
+    <xacro:property name="tf_prefix" value="${robot_namespace_slash if use_tf_prefix in ['True', True] else ''}" />
     <xacro:property name="component_name_underscore" value="${component_name + '_' if component_name != '' else ''}" />
     <xacro:property name="component_name_slash" value="${component_name + '/' if component_name != '' else ''}" />
 
@@ -80,7 +82,7 @@ limitations under the License.
         <always_on>1</always_on>
         <update_rate>1</update_rate>
         <topic>${robot_namespace_slash}${component_name_slash}fix</topic>
-        <gz_frame_id>${robot_namespace_slash}${component_name_underscore}antenna</gz_frame_id>
+        <gz_frame_id>${tf_prefix}${component_name_underscore}antenna</gz_frame_id>
       </sensor>
     </gazebo>
   </xacro:macro>

--- a/urdf/velodyne_puck.urdf.xacro
+++ b/urdf/velodyne_puck.urdf.xacro
@@ -22,7 +22,8 @@ limitations under the License.
                        xyz:='0.0 0.0 0.0'
                        rpy:='0.0 0.0 0.0'
                        robot_namespace:=''
-                       component_name:=''">
+                       component_name:=''
+                       use_tf_prefix:=True">
 
     <!-- <xacro:if value="${component_name == ''}">
       <xacro:property name="component_name" value="velodyne" />
@@ -30,6 +31,7 @@ limitations under the License.
     <!-- ^ removed for compatibility with hw driver -->
 
     <xacro:property name="robot_namespace_slash" value="${robot_namespace + '/' if robot_namespace != '' else ''}" />
+    <xacro:property name="tf_prefix" value="${robot_namespace_slash if use_tf_prefix in ['True', True] else ''}" />
     <xacro:property name="component_name_underscore" value="${component_name + '_' if component_name != '' else ''}" />
     <xacro:property name="component_name_slash" value="${component_name + '/' if component_name != '' else ''}" />
 
@@ -121,7 +123,7 @@ limitations under the License.
         </ray>
 
         <topic>${robot_namespace_slash}${component_name_slash}velodyne_points</topic>
-        <gz_frame_id>${robot_namespace_slash}${component_name_underscore}velodyne</gz_frame_id>
+        <gz_frame_id>${tf_prefix}${component_name_underscore}velodyne</gz_frame_id>
         <always_on>true</always_on>
       </sensor>
     </gazebo>


### PR DESCRIPTION
### Description

- Enable to spawn sensor with namespace on rosbot
   <img width="1920" height="1080" alt="Screenshot from 2025-12-03 12-22-32" src="https://github.com/user-attachments/assets/8a6bafc6-a768-4fb0-b72e-d5ac86173b50" />
- Fix depthai reference (bug below):
   <img width="1130" height="311" alt="Screenshot from 2025-12-03 12-31-14" src="https://github.com/user-attachments/assets/7bad1374-0661-4264-aa43-a997e340e225" />
