### PR TITLE
Add custom component type for user URDF/mesh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,16 @@
 # husarion_components_description
 
-URDF models of sensors and other components offered alongside with Husarion robots
+URDF models of sensors and other components offered alongside Husarion robots.
 
-## Available URDF Sensors
+## Overview
 
-<div align="center">
+Components (cameras, lidars, frames, manipulators, …) are attached to a robot from a
+single YAML config: a list of entries, each picking a component by its `type` code and
+placing it on a parent link. Husarion robot packages (e.g. `rosbot_description`) read this
+config and build the URDF for you; you can also instantiate a component's xacro macro
+directly (see [Advanced](#advanced-direct-xacro-include)).
 
-| Code   | Device Name                  |
-| ------ | ---------------------------- |
-| DEV01  | Cover with Access Panel      |
-| DEV02  | Carrying Handles             |
-| DEV03  | Wooden Mounting Plate        |
-| DEV04H | 370 mm High Frame            |
-| DEV04L | 170 mm High Frame            |
-| DEV05  | 350 mm Pillar                |
-| DEV06  | Basket on Railings           |
-| DEV07  | 475 mm Small Gate            |
-| DEV07T | 350 mm Rotated Small Gate    |
-| DEV09  | Large Gate                   |
-| ANT02  | Teltonika 003R-00253         |
-| CAM01  | Orbbec Astra                 |
-| CAM03  | StereoLabs ZED 2             |
-| CAM04  | StereoLabs ZED 2i            |
-| CAM05  | StereoLabs ZED M             |
-| CAM06  | StereoLabs ZED X             |
-| CAM11  | Luxonis OAK-D-PRO            |
-| LDR01  | RPLIDAR S1                   |
-| LDR06  | RPLIDAR S3                   |
-| LDR10  | Ouster OS0-32                |
-| LDR11  | Ouster OS0-64                |
-| LDR12  | Ouster OS0-128               |
-| LDR13  | Ouster OS1-32                |
-| LDR14  | Ouster OS1-64                |
-| LDR15  | Ouster OS1-128               |
-| LDR20  | Velodyne Puck                |
-| MAN01  | Universal Robots UR3e        |
-| MAN02  | Universal Robots UR5e        |
-| MAN04  | 6DoF Kinova Gen3             |
-| MAN05  | 6DoF Kinova Gen3 + 3D vision |
-| MAN06  | 7DoF Kinova Gen3             |
-| MAN07  | 7DoF Kinova Gen3 + 3D vision |
-| GRP02  | Robotiq 2F-85                |
-| WCH01  | Wibotic receiver             |
-| RCK    | Custom rack made of profiles |
-
-</div>
-
-> [!NOTE]
-> The manipulators (code `MAN<X>`) must only be used within the simulation environment.
-> Support for manipulators on a physical robot is implemented as separate software components.
-> Please refer to [the official documentation](https://husarion.com/manuals/panther/manipulators).
-
-## Including sensor
-
-First build the package by running:
+## Build
 
 ```bash
 # create workspace folder and clone husarion_components_description
@@ -69,27 +26,167 @@ rosdep install -i --from-path src --rosdistro $ROS_DISTRO -y
 colcon build
 ```
 
-To include the sensor, use the following code:
+## Usage via config
+
+List the components you want under `components:`. Each entry selects a `type` (see
+[Available components](#available-components)) and where to mount it:
+
+```yaml
+components:
+  - type: LDR06
+    parent_link: cover_link
+    xyz: 0.0 0.0 0.2
+    rpy: 0.0 0.0 0.0
+
+  - type: CAM06
+    name: front
+    parent_link: camera_mount_link
+    xyz: -0.01 0.0 0.02
+    rpy: 0.0 0.0 0.0
+```
+
+### Config schema
+
+| field         | required | description                                                                         |
+| ------------- | -------- | ----------------------------------------------------------------------------------- |
+| `type`        | yes      | component code (see [Available components](#available-components)), or `custom`      |
+| `parent_link` | yes      | robot link the component is attached to                                             |
+| `name`        | no       | local name; prefixes the component's frames so identical devices don't collide      |
+| `xyz`         | no       | translation from `parent_link` `[m]`, default `0.0 0.0 0.0`                          |
+| `rpy`         | no       | rotation from `parent_link` `[rad]`, default `0.0 0.0 0.0`                           |
+
+Some types accept extra fields (e.g. `RCK` takes `elements`, `custom` takes `package`/`file`).
+
+## Available components
+
+### Frames & mounts
+
+| Code   | Device Name               |
+| ------ | ------------------------- |
+| DEV01  | Cover with Access Panel   |
+| DEV02  | Carrying Handles          |
+| DEV03  | Wooden Mounting Plate     |
+| DEV04H | 370 mm High Frame         |
+| DEV04L | 170 mm High Frame         |
+| DEV05  | 350 mm Pillar             |
+| DEV06  | Basket on Railings        |
+| DEV07  | 475 mm Small Gate         |
+| DEV07T | 350 mm Rotated Small Gate |
+| DEV09  | Large Gate                |
+| RCK    | Rack made of profiles     |
+
+### Cameras
+
+| Code  | Device Name      |
+| ----- | ---------------- |
+| CAM01 | Orbbec Astra     |
+| CAM03 | StereoLabs ZED 2 |
+| CAM04 | StereoLabs ZED 2i |
+| CAM05 | StereoLabs ZED M |
+| CAM06 | StereoLabs ZED X |
+| CAM11 | Luxonis OAK-D-PRO |
+
+### Lidars
+
+| Code  | Device Name    |
+| ----- | -------------- |
+| LDR01 | RPLIDAR S1     |
+| LDR06 | RPLIDAR S3     |
+| LDR10 | Ouster OS0-32  |
+| LDR11 | Ouster OS0-64  |
+| LDR12 | Ouster OS0-128 |
+| LDR13 | Ouster OS1-32  |
+| LDR14 | Ouster OS1-64  |
+| LDR15 | Ouster OS1-128 |
+| LDR20 | Velodyne Puck  |
+
+### Manipulators
+
+| Code  | Device Name                 |
+| ----- | --------------------------- |
+| MAN01 | Universal Robots UR3e       |
+| MAN02 | Universal Robots UR5e       |
+| MAN04 | 6DoF Kinova Gen3            |
+| MAN05 | 6DoF Kinova Gen3 + 3D vision |
+| MAN06 | 7DoF Kinova Gen3            |
+| MAN07 | 7DoF Kinova Gen3 + 3D vision |
+
+> [!NOTE]
+> The manipulators (code `MAN<X>`) must only be used within the simulation environment.
+> Support for manipulators on a physical robot is implemented as separate software components.
+> Please refer to [the official documentation](https://husarion.com/manuals/panther/manipulators).
+
+### Grippers
+
+| Code  | Device Name  |
+| ----- | ------------ |
+| GRP02 | Robotiq 2F-85 |
+
+### Connectivity & power
+
+| Code  | Device Name          |
+| ----- | -------------------- |
+| ANT02 | Teltonika 003R-00253 |
+| WCH01 | Wibotic receiver     |
+
+## Custom component
+
+Use `type: custom` to attach your own URDF/xacro (with its meshes) without adding a new
+component code. The referenced file must define a macro with the standard component
+signature (`parent_link`, `xyz`, `rpy`, `component_name`, `robot_namespace`,
+`use_tf_prefix`); its name defaults to `custom_component` and can be overridden with
+`macro_name`.
+See [urdf/custom_component_example.urdf.xacro](urdf/custom_component_example.urdf.xacro)
+for a runnable, copy-paste template.
+
+```yaml
+components:
+  - type: custom
+    package: my_robot_description # resolved as $(find package)/file
+    file: urdf/my_sensor.urdf.xacro
+    # ...or drop `package` and give an absolute path (handy locally, not portable):
+    # file: /home/user/my_sensor.urdf.xacro
+    # macro_name: my_macro # optional, defaults to custom_component
+    name: my_sensor
+    parent_link: cover_link
+    xyz: 0.0 0.0 0.1
+    rpy: 0.0 0.0 0.0
+```
+
+Fields specific to `custom`:
+
+| field        | required | description                                                                        |
+| ------------ | -------- | ---------------------------------------------------------------------------------- |
+| `package`    | no       | ROS package containing `file`. Omit to use an absolute `file` path (handy locally, but not portable - prefer a package) |
+| `file`       | yes      | path to your xacro; resolved against `package` when present, otherwise absolute     |
+| `macro_name` | no       | name of the macro to call inside `file`, default `custom_component`                 |
+
+Reference meshes from your package with `package://my_robot_description/meshes/...`
+(portable), or - only with the absolute-path form - by an absolute `file://` URI.
+
+## Advanced: direct xacro include
+
+Instead of the config you can instantiate a component's macro directly in your own xacro:
 
 ```xml
-<!-- include file with definition of xacro macro of sensor -->
+<!-- include file with definition of xacro macro of the component -->
 <xacro:include filename="$(find husarion_components_description)/urdf/slamtec_rplidar.urdf.xacro" ns="lidar" />
 
-<!-- evaluate the macro and place the sensor on robot -->
+<!-- evaluate the macro and place the component on the robot -->
 <xacro:lidar.slamtec_rplidar
   parent_link="cover_link"
   xyz="0.0 0.0 0.0"
   rpy="0.0 0.0 0.0" />
 ```
 
-List of parameters:
+Common macro parameters:
 
-- `component_name` [*string*, default: **''**] local namespace allowing to distinguish two identical devices from each other. Called `name` in `components.yaml`.
-- `parent_link` [*string*, default: **None**] parent link to which sensor should be attached.
-- `xyz` [*float list*, default: **0.0 0.0 0.0**] 3 float values defining translation between base of a sensor and parent link. Values in **m**.
-- `rpy` [*float list*, default: **0.0 0.0 0.0**] 3 float values define rotation between parent link and base of a sensor. Values in **rad**.
-- `robot_namespace` [*string*, default: **''**] global namespace common to the entire robot. Not present in  `components.yaml`.
-- `model` [*string*, default: **''**] model argument that appears when you want to load the appropriate model from a given manufacturer. Not present in `components.yaml`.
-- `use_tf_prefix` [*bool*, default: **True**] if set to True, the `robot_namespace` will be used as a prefix for all frame_ids defined in the sensor URDF. This is useful when every robot has its own tf tree. Not present in `components.yaml`.
+- `component_name` [*string*, default: **''**] local namespace to distinguish two identical devices. Called `name` in the config.
+- `parent_link` [*string*, default: **None**] parent link to which the component is attached.
+- `xyz` [*float list*, default: **0.0 0.0 0.0**] translation between the component base and parent link, in **m**.
+- `rpy` [*float list*, default: **0.0 0.0 0.0**] rotation between the parent link and component base, in **rad**.
+- `robot_namespace` [*string*, default: **''**] global namespace common to the entire robot. Not present in the config.
+- `model` [*string*, default: **''**] selects the manufacturer model variant. Not present in the config.
+- `use_tf_prefix` [*bool*, default: **True**] use `robot_namespace` as a prefix for all frame_ids. Useful when every robot has its own tf tree. Not present in the config.
 
-Some sensors can define their specific parameters. Refer to their definition for more info.
+Some components define their own specific parameters - refer to their definition for more info.

--- a/test/test_components_xacro.py
+++ b/test/test_components_xacro.py
@@ -207,3 +207,76 @@ def test_all_good_single_components(tmpdir_factory):
 
         for component in components["components"]:
             utils.test_component(component, [True, True, True], str(components_config_path))
+
+
+EXAMPLE_XACRO = os.path.join(
+    husarion_components_description, "urdf/custom_component_example.urdf.xacro"
+)
+
+
+def _render_custom(tmpdir_factory, folder, entry):
+    config_path = tmpdir_factory.mktemp(folder).join("config.yaml")
+    with open(str(config_path), mode="w", encoding="utf-8") as file:
+        yaml.dump({"components": [entry]}, file)
+    utils = ComponentsYamlParseUtils(str(config_path))
+    assert utils.does_urdf_parse(), f"custom component failed to parse: {entry}"
+    return utils
+
+
+def test_custom_component_with_package(tmpdir_factory):
+    utils = _render_custom(
+        tmpdir_factory,
+        "custom_pkg",
+        {
+            "type": "custom",
+            "name": "my_sensor",
+            "package": "husarion_components_description",
+            "file": "urdf/custom_component_example.urdf.xacro",
+            "parent_link": "cover_link",
+            "xyz": "0.0 0.0 0.1",
+            "rpy": "0.0 0.0 0.0",
+        },
+    )
+    assert utils.does_link_exist(utils._urdf, "my_sensor_link")
+
+
+def test_custom_component_with_absolute_path(tmpdir_factory):
+    utils = _render_custom(
+        tmpdir_factory,
+        "custom_abs",
+        {
+            "type": "custom",
+            "name": "my_sensor",
+            "file": EXAMPLE_XACRO,
+            "parent_link": "cover_link",
+        },
+    )
+    assert utils.does_link_exist(utils._urdf, "my_sensor_link")
+
+
+def test_custom_component_with_macro_name_override(tmpdir_factory):
+    fixture = tmpdir_factory.mktemp("custom_macro").join("renamed.urdf.xacro")
+    with open(str(fixture), mode="w", encoding="utf-8") as file:
+        file.write(
+            '<robot xmlns:xacro="http://wiki.ros.org/xacro">'
+            '<xacro:macro name="my_macro" '
+            "params=\"parent_link xyz:='0 0 0' rpy:='0 0 0' "
+            "component_name:='' robot_namespace:='' use_tf_prefix:=True\">"
+            '<link name="${component_name}_link"/>'
+            '<joint name="${parent_link}_to_${component_name}_joint" type="fixed">'
+            '<parent link="${parent_link}"/><child link="${component_name}_link"/>'
+            '<origin xyz="${xyz}" rpy="${rpy}"/></joint>'
+            "</xacro:macro></robot>"
+        )
+    utils = _render_custom(
+        tmpdir_factory,
+        "custom_macro_cfg",
+        {
+            "type": "custom",
+            "name": "renamed",
+            "file": str(fixture),
+            "macro_name": "my_macro",
+            "parent_link": "cover_link",
+        },
+    )
+    assert utils.does_link_exist(utils._urdf, "renamed_link")

--- a/urdf/components.urdf.xacro
+++ b/urdf/components.urdf.xacro
@@ -387,6 +387,32 @@ limitations under the License.
             component_name="${component_name}"
           />
         </xacro:if>
+
+        <!-- User-supplied URDF/xacro. `file` is resolved against `package` when -->
+        <!-- present ($(find package)/file), otherwise taken as an absolute path. -->
+        <!-- The included file must define a macro with the standard component -->
+        <!-- signature; its name defaults to `custom_component` and is overridable -->
+        <!-- via `macro_name`. -->
+        <xacro:if value="${type == 'custom'}">
+          <xacro:property name="macro_name"
+            value="${component['macro_name'] if 'macro_name' in component else 'custom_component'}" scope="parent" />
+
+          <xacro:if value="${'package' in component}">
+            <xacro:include filename="$(find ${component['package']})/${component['file']}" ns="custom" />
+          </xacro:if>
+          <xacro:unless value="${'package' in component}">
+            <xacro:include filename="${component['file']}" ns="custom" />
+          </xacro:unless>
+
+          <xacro:call macro="custom.${macro_name}"
+            parent_link="${parent_link}"
+            xyz="${xyz}"
+            rpy="${rpy}"
+            robot_namespace="${robot_namespace}"
+            component_name="${component_name}"
+            use_tf_prefix="${use_tf_prefix}"
+          />
+        </xacro:if>
       </xacro:unless>
 
       <xacro:if value="${index}">

--- a/urdf/custom_component_example.urdf.xacro
+++ b/urdf/custom_component_example.urdf.xacro
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+
+<!--
+Copyright 2025 Husarion. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!--
+  Runnable example of a `type: custom` component. Copy this file into your own
+  package and reshape the macro body for your hardware - keep the parameter
+  signature (the components dispatcher calls it with all of them). The macro name
+  defaults to `custom_component`; rename it and point at it via `macro_name` in the config.
+
+  Reference it from a components config:
+
+    - type: custom
+      package: husarion_components_description   # omit for an absolute `file` path
+      file: urdf/custom_component_example.urdf.xacro
+      name: my_sensor
+      parent_link: cover_link
+      xyz: 0.0 0.0 0.1
+      rpy: 0.0 0.0 0.0
+-->
+
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
+  <xacro:macro name="custom_component"
+               params="parent_link
+                       xyz:='0.0 0.0 0.0'
+                       rpy:='0.0 0.0 0.0'
+                       component_name:=''
+                       robot_namespace:=''
+                       use_tf_prefix:=True">
+
+    <link name="${component_name}_link">
+      <visual>
+        <geometry>
+          <!-- Mesh resolved via package:// (portable). Swap for your own asset,
+               e.g. package://my_robot_description/meshes/my_sensor.dae, or an
+               absolute file:///... path when the component has no package. -->
+          <mesh filename="package://husarion_components_description/meshes/teltonika_003R-00253.dae" />
+        </geometry>
+      </visual>
+      <collision>
+        <geometry>
+          <box size="0.04 0.04 0.1" />
+        </geometry>
+      </collision>
+    </link>
+
+    <joint name="${parent_link}_to_${component_name}_joint" type="fixed">
+      <parent link="${parent_link}" />
+      <child link="${component_name}_link" />
+      <origin xyz="${xyz}" rpy="${rpy}" />
+    </joint>
+  </xacro:macro>
+</robot>


### PR DESCRIPTION
## What & why

Adds a `type: custom` component so users can attach their **own** URDF/xacro + meshes without adding a new component code to this package.

## Usage

```yaml
components:
  - type: custom
    name: my_sensor
    package: my_robot_description   # or omit + use an absolute `file` path
    file: urdf/my_sensor.urdf.xacro
    parent_link: cover_link
    xyz: 0.0 0.0 0.1
    rpy: 0.0 0.0 0.0
    # macro_name: my_macro          # optional, defaults to custom_component
```

The file defines a macro with the standard component signature (name defaults to `custom_component`, overridable via `macro_name`). Runnable template: `urdf/custom_component_example.urdf.xacro`.

## Notes

- Path resolution: `$(find ${package})/${file}` resolves from a YAML string; a single `$(find ...)` string does not. Hence the `package` + relative `file` split, with an absolute-path fallback when `package` is omitted.
- Dynamic macro name via `xacro:call macro="custom.${macro_name}"`.
- README reworked: overview / build / config usage + schema / grouped component tables / custom / advanced direct-include.

## Tests

`test/test_components_xacro.py` - package+file, absolute-path and macro_name-override cases + existing regression → 4 passed. Verified end-to-end in Gazebo (mesh renders on GPU, no load errors).