### PR TITLE
Update simulated ZED topics for SDK v5

### DIFF
--- a/config/gz_stereolabs_zed_remappings.yaml
+++ b/config/gz_stereolabs_zed_remappings.yaml
@@ -1,30 +1,31 @@
 ---
 # https://github.com/stereolabs/zed-ros2-wrapper
-  - topic_name: <robot_namespace><component_name>/zed_node/rgb/camera_info
+  - topic_name: <robot_namespace><component_name>/zed_node/rgb/color/rect/camera_info
     ros_type_name: sensor_msgs/msg/CameraInfo
     gz_type_name: gz.msgs.CameraInfo
     lazy: true
     direction: GZ_TO_ROS
 
-  - topic_name: <robot_namespace><component_name>/zed_node/rgb/image_rect_color
+  - topic_name: <robot_namespace><component_name>/zed_node/rgb/color/rect/image
     ros_type_name: sensor_msgs/msg/Image
     gz_type_name: gz.msgs.Image
     lazy: true
     direction: GZ_TO_ROS
 
-  - topic_name: <robot_namespace><component_name>/zed_node/camera_info
+  - topic_name: <robot_namespace><component_name>/zed_node/depth/camera_info
     ros_type_name: sensor_msgs/msg/CameraInfo
     gz_type_name: gz.msgs.CameraInfo
     lazy: true
     direction: GZ_TO_ROS
 
-  - topic_name: <robot_namespace><component_name>/zed_node/depth
+  - topic_name: <robot_namespace><component_name>/zed_node/depth/depth_registered
     ros_type_name: sensor_msgs/msg/Image
     gz_type_name: gz.msgs.Image
     lazy: true
     direction: GZ_TO_ROS
 
-  - topic_name: <robot_namespace><component_name>/zed_node/depth/points
+  - ros_topic_name: <robot_namespace><component_name>/zed_node/point_cloud/cloud_registered
+    gz_topic_name: <robot_namespace><component_name>/zed_node/depth/depth_registered/points
     ros_type_name: sensor_msgs/msg/PointCloud2
     gz_type_name: gz.msgs.PointCloudPacked
     lazy: true

--- a/test/test_components_xacro.py
+++ b/test/test_components_xacro.py
@@ -138,6 +138,17 @@ class ComponentsYamlParseUtils:
 
         return False
 
+    def get_sensor_topic(self, sensor_name: str) -> str:
+        for sensor in self._urdf.getElementsByTagName("sensor"):
+            if sensor.getAttribute("name") != sensor_name:
+                continue
+
+            topics = sensor.getElementsByTagName("topic")
+            if len(topics) == 1 and topics[0].firstChild is not None:
+                return topics[0].firstChild.data
+
+        raise AssertionError(f"Topic for sensor {sensor_name} not found")
+
     def test_component(self, component: dict, expected_result: list, components_config_path: str):
         names = components_types_with_names[component["type"]]
         component_model_name = names[0]
@@ -207,6 +218,28 @@ def test_all_good_single_components(tmpdir_factory):
 
         for component in components["components"]:
             utils.test_component(component, [True, True, True], str(components_config_path))
+
+
+def test_zed_uses_v5_topics(tmpdir_factory):
+    components_config_path = tmpdir_factory.mktemp("zed_v5").join("components.yaml")
+    utils = ComponentsYamlParseUtils(str(components_config_path))
+    utils.save_yaml(
+        {
+            "components": [
+                utils.create_component("CAM03", "front_camera"),
+            ],
+        }
+    )
+
+    assert utils.does_urdf_parse()
+    assert (
+        utils.get_sensor_topic("front_camera_camera_color")
+        == "front_camera/zed_node/rgb/color/rect/image"
+    )
+    assert (
+        utils.get_sensor_topic("front_camera_camera_depth")
+        == "front_camera/zed_node/depth/depth_registered"
+    )
 
 
 EXAMPLE_XACRO = os.path.join(

--- a/urdf/stereolabs_zed.urdf.xacro
+++ b/urdf/stereolabs_zed.urdf.xacro
@@ -55,7 +55,7 @@ limitations under the License.
     <xacro:gz_sensor.camera
       reference="${component_name}_camera_center"
       name="${robot_namespace_slash}${component_name}_camera_color"
-      topic="${robot_namespace_slash}${component_name}/zed_node/rgb/image_rect_color"
+      topic="${robot_namespace_slash}${component_name}/zed_node/rgb/color/rect/image"
       frame_id="${tf_prefix}${component_name}_camera_center"
       frequency="30"
       width="1280"
@@ -65,7 +65,7 @@ limitations under the License.
     <xacro:gz_sensor.depth_camera
       reference="${component_name}_camera_center"
       name="${robot_namespace_slash}${component_name}_camera_depth"
-      topic="${robot_namespace_slash}${component_name}/zed_node/depth"
+      topic="${robot_namespace_slash}${component_name}/zed_node/depth/depth_registered"
       frame_id="${tf_prefix}${component_name}_camera_center"
       frequency="30"
       width="1280"


### PR DESCRIPTION
## Summary

- update simulated ZED RGB and depth topics to the ZED ROS 2 wrapper v5 naming convention
- bridge Gazebo depth-camera point clouds to `point_cloud/cloud_registered`
- add a regression test for the generated RGB and depth sensor topics

Closes #18.

## Validation

- `git diff --check`
- Python syntax compilation for the test suite
- YAML parsed and all five bridge entries checked
- modified Xacro files validated as well-formed XML

The full ROS 2/Xacro suite was not available in the local macOS environment, so the repository CI is the authoritative integration check.